### PR TITLE
Fix package list for PHP extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The script performs the following steps:
     - Sets up MySQL for database management.
 
 6. **Installs required PHP extensions:**
-    - Includes all the necessary extensions for Laravel 11, such as `BCMath`, `Ctype`, `Fileinfo`, `JSON`, `Mbstring`, `OpenSSL`, `PDO`, `Tokenizer`, `XML`, `MySQL`, `Curl`, and `Zip`.
+    - Laravel 11 requires several PHP extensions. Many of them (including `Ctype`, `Fileinfo`, `JSON`, `OpenSSL`, `PDO`, and `Tokenizer`) are bundled with PHP 8.2 and do not need separate packages. The script installs the remaining modules: `BCMath`, `Mbstring`, `XML`, `MySQL`, `Curl`, and `Zip`.
 
 7. **Enables Apache and PHP modules:**
     - Enables `mod_rewrite` for Apache, which is required for Laravel routing.

--- a/ubuntu24.sh
+++ b/ubuntu24.sh
@@ -15,7 +15,19 @@ echo "Installing MySQL Server";
 sudo apt-get install -y mysql-server
 
 echo "Installing PHP extensions required for Laravel 11";
-sudo apt-get install -y php-bcmath php-ctype php-fileinfo php-json php-mbstring php-openssl php-pdo php-tokenizer php-xml php-mysql php-curl php-zip php-apcu php-imagick
+# PHP 8.2 ships several extensions (such as ctype, fileinfo, JSON, openssl,
+# PDO and tokenizer) as part of the core package. Installing them via
+# `apt-get` would fail because there are no separate packages. Only modules
+# that are distributed as packages need to be installed explicitly.
+sudo apt-get install -y \
+    php-bcmath \
+    php-mbstring \
+    php-xml \
+    php-mysql \
+    php-curl \
+    php-zip \
+    php-apcu \
+    php-imagick
 
 echo "Enabling Apache2 and PHP modules";
 sudo apt-get install -y libapache2-mod-php


### PR DESCRIPTION
## Summary
- fix incorrect package names in `ubuntu24.sh`
- clarify which PHP extensions are installed in the README

## Testing
- `apt-get -s install php-openssl | head`


------
https://chatgpt.com/codex/tasks/task_e_684b1587efa4832cbf29e0c22440002d