### PR TITLE
Fix restart apache typos

### DIFF
--- a/ubuntu14.sh
+++ b/ubuntu14.sh
@@ -20,7 +20,7 @@ sudo php5enmod mcrypt
 echo "apache mods"
 sudo a2enmod rewrite
 
-echo "restar apache"
+echo "restart apache"
 sudo service apache2 restart
 
 

--- a/ubuntu16-PHP7.sh
+++ b/ubuntu16-PHP7.sh
@@ -35,7 +35,7 @@ echo "apache mods"
 sudo apt-get install libapache2-mod-php -y
 sudo a2enmod rewrite
 
-echo "restar apache"
+echo "restart apache"
 sudo service apache2 restart
 
 

--- a/ubuntu16.sh
+++ b/ubuntu16.sh
@@ -24,7 +24,7 @@ echo "apache mods"
 sudo apt-get install libapache2-mod-php
 sudo a2enmod rewrite
 
-echo "restar apache"
+echo "restart apache"
 sudo service apache2 restart
 
 

--- a/ubuntu17.sh
+++ b/ubuntu17.sh
@@ -29,5 +29,5 @@ echo "apache mods"
 sudo apt-get install libapache2-mod-php -y
 sudo a2enmod rewrite
 
-echo "restar apache"
+echo "restart apache"
 sudo service apache2 restart


### PR DESCRIPTION
## Summary
- correct 'restar apache' typo across startup scripts

## Testing
- `shellcheck ubuntu14.sh ubuntu16-PHP7.sh ubuntu16.sh ubuntu17.sh`

------
https://chatgpt.com/codex/tasks/task_e_684dae563114832c92942099835f281a